### PR TITLE
added delete trip

### DIFF
--- a/app/(app)/(no-trip)/index.tsx
+++ b/app/(app)/(no-trip)/index.tsx
@@ -1,323 +1,368 @@
 import { useState, useEffect, useCallback } from 'react';
 import {
-  View,
-  Text,
-  TextInput,
-  Pressable,
-  ActivityIndicator,
-  Alert,
-  StyleSheet,
-  ScrollView,
-  RefreshControl,
+	View,
+	Text,
+	TextInput,
+	Pressable,
+	ActivityIndicator,
+	Alert,
+	StyleSheet,
+	ScrollView,
+	RefreshControl,
 } from 'react-native';
 import { router } from 'expo-router';
-import { createTripSchema } from '@/types/trip.types';
+import { createTripSchema, TripRole } from '@/types/trip.types';
 import { useTripStore } from '@/store/trip.store';
 import { useProfileStore } from '@/store/profile.store';
 import { useAuthStore } from '@/store/auth.store';
 
 export default function TripPickerScreen() {
-  const [name, setName] = useState('');
-  const [description, setDescription] = useState('');
-  const [error, setError] = useState<string | null>(null);
-  const [selectionError, setSelectionError] = useState<string | null>(null);
-  const [refreshing, setRefreshing] = useState(false);
-  const [selectingTripId, setSelectingTripId] = useState<string | null>(null);
-  const [leavingTripId, setLeavingTripId] = useState<string | null>(null);
+	const [name, setName] = useState('');
+	const [description, setDescription] = useState('');
+	const [error, setError] = useState<string | null>(null);
+	const [selectionError, setSelectionError] = useState<string | null>(null);
+	const [refreshing, setRefreshing] = useState(false);
+	const [selectingTripId, setSelectingTripId] = useState<string | null>(null);
+	const [leavingTripId, setLeavingTripId] = useState<string | null>(null);
 
-  const { createTrip, fetchTrips, trips, isLoading, leaveTrip } = useTripStore();
-  const { setSelectedTrip } = useProfileStore();
-  const { session } = useAuthStore();
+	const { createTrip, fetchTrips, trips, isLoading, leaveTrip, deleteTrip } = useTripStore();
+	const { setSelectedTrip } = useProfileStore();
+	const { session } = useAuthStore();
 
-  useEffect(() => {
-    fetchTrips();
-  }, []);
+	useEffect(() => {
+		fetchTrips();
+	}, []);
 
-  const handleRefresh = useCallback(async () => {
-    setRefreshing(true);
-    try {
-      await fetchTrips();
-    } finally {
-      setRefreshing(false);
-    }
-  }, [fetchTrips]);
+	const handleRefresh = useCallback(async () => {
+		setRefreshing(true);
+		try {
+			await fetchTrips();
+		} finally {
+			setRefreshing(false);
+		}
+	}, [fetchTrips]);
 
+	async function handleCreate() {
+		setError(null);
 
-  async function handleCreate() {
-    setError(null);
+		const result = createTripSchema.safeParse({
+			name,
+			description: description || null,
+		});
 
-    const result = createTripSchema.safeParse({
-      name,
-      description: description || null,
-    });
+		if (!result.success) {
+			setError(result.error.issues[0].message);
+			return;
+		}
 
-    if (!result.success) {
-      setError(result.error.issues[0].message);
-      return;
-    }
+		try {
+			await createTrip(result.data);
+			setName('');
+			setDescription('');
+		} catch {
+			setError('Failed to create trip. Please try again.');
+		}
+	}
 
-    try {
-      await createTrip(result.data);
-      setName('');
-      setDescription('');
-    } catch {
-      setError('Failed to create trip. Please try again.');
-    }
-  }
+	async function handleSelectTrip(tripId: string) {
+		setSelectionError(null);
+		setSelectingTripId(tripId);
+		try {
+			await setSelectedTrip(tripId);
+		} catch (error: any) {
+			setSelectionError(error?.message ?? 'Failed to select trip');
+		} finally {
+			setSelectingTripId(null);
+		}
+	}
 
-  async function handleSelectTrip(tripId: string) {
-    setSelectionError(null);
-    setSelectingTripId(tripId);
-    try {
-      await setSelectedTrip(tripId);
-    } catch (error: any) {
-      setSelectionError(error?.message ?? 'Failed to select trip');
-    } finally {
-      setSelectingTripId(null);
-    }
-  }
+	function handleLeaveTrip(tripId: string, tripName: string) {
+		Alert.alert(
+			'Leave Trip',
+			`Are you sure you want to leave "${tripName}"?`,
+			[
+				{ text: 'Cancel', style: 'cancel' },
+				{
+					text: 'Leave',
+					style: 'destructive',
+					onPress: async () => {
+						setLeavingTripId(tripId);
+						try {
+							await leaveTrip(tripId);
+						} catch {
+							setSelectionError('Failed to leave trip. Please try again.');
+						} finally {
+							setLeavingTripId(null);
+						}
+					},
+				},
+			],
+		);
+	}
 
-  function handleLeaveTrip(tripId: string, tripName: string) {
-    Alert.alert(
-      'Leave Trip',
-      `Are you sure you want to leave "${tripName}"?`,
-      [
-        { text: 'Cancel', style: 'cancel' },
-        {
-          text: 'Leave',
-          style: 'destructive',
-          onPress: async () => {
-            setLeavingTripId(tripId);
-            try {
-              await leaveTrip(tripId);
-            } catch {
-              setSelectionError('Failed to leave trip. Please try again.');
-            } finally {
-              setLeavingTripId(null);
-            }
-          },
-        },
-      ],
-    );
-  }
+	function handleDeleteTrip(tripId: string, tripName: string) {
+		Alert.alert(
+			'Delete Trip',
+			`Are you sure you want to delete "${tripName}"? This cannot be undone.`,
+			[
+				{ text: 'Cancel', style: 'cancel' },
+				{
+					text: 'Delete',
+					style: 'destructive',
+					onPress: async () => {
+						try {
+							await deleteTrip(tripId);
+						} catch (error: any) {
+							Alert.alert('Error', error?.message ?? 'Failed to delete trip.');
+						}
+					},
+				},
+			],
+		);
+	}
 
-  function handleJoinWithCode() {
-    router.push('/join');
-  }
+	function handleJoinWithCode() {
+		router.push('/join');
+	}
 
-  return (
-    <ScrollView
-      contentContainerStyle={styles.container}
-      refreshControl={<RefreshControl refreshing={refreshing} onRefresh={handleRefresh} />}
-    >
-      <Text style={styles.debug}>DEBUG user id: {session?.user.id ?? 'no session'}</Text>
-      <Text style={styles.title}>My Trips</Text>
-      <Text style={styles.subtitle}>Create a new trip to get started</Text>
+	return (
+		<ScrollView
+			contentContainerStyle={styles.container}
+			refreshControl={<RefreshControl refreshing={refreshing} onRefresh={handleRefresh} />}
+		>
+			<Text style={styles.debug}>DEBUG user id: {session?.user.id ?? 'no session'}</Text>
+			<Text style={styles.title}>My Trips</Text>
+			<Text style={styles.subtitle}>Create a new trip to get started</Text>
 
-      <TextInput
-        style={styles.input}
-        placeholder="Trip name"
-        value={name}
-        onChangeText={setName}
-        autoCapitalize="words"
-      />
-      <TextInput
-        style={[styles.input, styles.inputMultiline]}
-        placeholder="Description (optional)"
-        value={description}
-        onChangeText={setDescription}
-        multiline
-        numberOfLines={3}
-      />
+			<TextInput
+				style={styles.input}
+				placeholder="Trip name"
+				value={name}
+				onChangeText={setName}
+				autoCapitalize="words"
+			/>
+			<TextInput
+				style={[styles.input, styles.inputMultiline]}
+				placeholder="Description (optional)"
+				value={description}
+				onChangeText={setDescription}
+				multiline
+				numberOfLines={3}
+			/>
 
-      {error && <Text style={styles.error}>{error}</Text>}
+			{error && <Text style={styles.error}>{error}</Text>}
 
-      <Pressable
-        style={({ pressed }) => [styles.button, pressed && styles.buttonPressed]}
-        onPress={handleCreate}
-        disabled={isLoading}
-      >
-        {isLoading
-          ? <ActivityIndicator color="#fff" />
-          : <Text style={styles.buttonText}>Create Trip</Text>
-        }
-      </Pressable>
+			<Pressable
+				style={({ pressed }) => [styles.button, pressed && styles.buttonPressed]}
+				onPress={handleCreate}
+				disabled={isLoading}
+			>
+				{isLoading
+					? <ActivityIndicator color="#fff" />
+					: <Text style={styles.buttonText}>Create Trip</Text>
+				}
+			</Pressable>
 
-      <Pressable
-        style={({ pressed }) => [styles.secondaryButton, pressed && styles.secondaryButtonPressed]}
-        onPress={handleJoinWithCode}
-      >
-        <Text style={styles.secondaryButtonText}>Have an invite code?</Text>
-      </Pressable>
+			<Pressable
+				style={({ pressed }) => [styles.secondaryButton, pressed && styles.secondaryButtonPressed]}
+				onPress={handleJoinWithCode}
+			>
+				<Text style={styles.secondaryButtonText}>Have an invite code?</Text>
+			</Pressable>
 
-      {selectionError && <Text style={styles.error}>{selectionError}</Text>}
+			{selectionError && <Text style={styles.error}>{selectionError}</Text>}
 
-      {trips.length > 0 && (
-        <View style={styles.tripList}>
-          <Text style={styles.listTitle}>Select a trip</Text>
-          <Text style={styles.listSubtitle}>Tap a trip to start planning</Text>
-          {trips.map((trip) => (
-            <View key={trip.id} style={styles.tripRow}>
-              <Pressable
-                style={({ pressed }) => [styles.tripItem, pressed && styles.tripItemPressed]}
-                onPress={() => handleSelectTrip(trip.id)}
-                disabled={selectingTripId !== null || leavingTripId !== null}
-              >
-                <Text style={styles.tripName}>{trip.name}</Text>
-                {trip.description && (
-                  <Text style={styles.tripDescription}>{trip.description}</Text>
-                )}
-                {selectingTripId === trip.id && <ActivityIndicator size="small" color="#3b82f6" />}
-              </Pressable>
-              <Pressable
-                style={({ pressed }) => [styles.leaveButton, pressed && styles.leaveButtonPressed]}
-                onPress={() => handleLeaveTrip(trip.id, trip.name)}
-                disabled={selectingTripId !== null || leavingTripId !== null}
-              >
-                {leavingTripId === trip.id
-                  ? <ActivityIndicator size="small" color="#e53e3e" />
-                  : <Text style={styles.leaveButtonText}>Leave</Text>
-                }
-              </Pressable>
-            </View>
-          ))}
-        </View>
-      )}
-    </ScrollView>
-  );
+			{trips.length > 0 && (
+				<View style={styles.tripList}>
+					<Text style={styles.listTitle}>Select a trip</Text>
+					<Text style={styles.listSubtitle}>Tap a trip to start planning</Text>
+					{trips.map((trip) => (
+						<View key={trip.id} style={styles.tripRow}>
+							<Pressable
+								style={({ pressed }) => [styles.tripItem, pressed && styles.tripItemPressed]}
+								onPress={() => handleSelectTrip(trip.id)}
+								disabled={selectingTripId !== null || leavingTripId !== null}
+							>
+								<Text style={styles.tripName}>{trip.name}</Text>
+								{trip.description && (
+									<Text style={styles.tripDescription}>{trip.description}</Text>
+								)}
+								{selectingTripId === trip.id && <ActivityIndicator size="small" color="#3b82f6" />}
+							</Pressable>
+							<Pressable
+								style={({ pressed }) => [styles.leaveButton, pressed && styles.leaveButtonPressed]}
+								onPress={() => handleLeaveTrip(trip.id, trip.name)}
+								disabled={selectingTripId !== null || leavingTripId !== null}
+							>
+								{leavingTripId === trip.id
+									? <ActivityIndicator size="small" color="#e53e3e" />
+									: <Text style={styles.leaveButtonText}>Leave</Text>
+								}
+							</Pressable>
+							{trip.userRole === TripRole.Organizer && (
+								<Pressable
+									style={({ pressed }) => [styles.deleteButton, pressed && styles.deleteButtonPressed]}
+									onPress={() => handleDeleteTrip(trip.id, trip.name)}
+									disabled={selectingTripId !== null || leavingTripId !== null}
+								>
+									<Text style={styles.deleteButtonText}>Delete</Text>
+								</Pressable>
+							)}
+						</View>
+					))}
+				</View>
+			)}
+		</ScrollView>
+	);
 }
 
 const styles = StyleSheet.create({
-  debug: {
-    fontSize: 11,
-    color: '#999',
-    fontFamily: 'monospace',
-    marginBottom: 8,
-  },
-  container: {
-    flexGrow: 1,
-    padding: 24,
-    paddingTop: 64,
-  },
-  title: {
-    fontSize: 28,
-    fontWeight: 'bold',
-    marginBottom: 4,
-  },
-  subtitle: {
-    fontSize: 14,
-    color: '#666',
-    marginBottom: 32,
-  },
-  input: {
-    borderWidth: 1,
-    borderColor: '#ddd',
-    borderRadius: 8,
-    padding: 12,
-    fontSize: 16,
-    marginBottom: 12,
-    backgroundColor: '#fff',
-  },
-  inputMultiline: {
-    height: 80,
-    textAlignVertical: 'top',
-  },
-  error: {
-    color: '#e53e3e',
-    fontSize: 14,
-    marginBottom: 12,
-  },
-  button: {
-    backgroundColor: '#3b82f6',
-    borderRadius: 8,
-    padding: 14,
-    alignItems: 'center',
-    marginTop: 4,
-  },
-  buttonPressed: {
-    opacity: 0.8,
-  },
-  buttonText: {
-    color: '#fff',
-    fontSize: 16,
-    fontWeight: '600',
-  },
-  secondaryButton: {
-    backgroundColor: 'transparent',
-    borderWidth: 1,
-    borderColor: '#3b82f6',
-    borderRadius: 8,
-    padding: 14,
-    alignItems: 'center',
-    marginTop: 12,
-  },
-  secondaryButtonPressed: {
-    opacity: 0.7,
-    backgroundColor: '#f0f7ff',
-  },
-  secondaryButtonText: {
-    color: '#3b82f6',
-    fontSize: 16,
-    fontWeight: '600',
-  },
-  tripList: {
-    marginTop: 40,
-  },
-  listTitle: {
-    fontSize: 16,
-    fontWeight: '600',
-    marginBottom: 4,
-    color: '#333',
-  },
-  listSubtitle: {
-    fontSize: 13,
-    color: '#666',
-    marginBottom: 16,
-  },
-  tripRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    marginBottom: 8,
-    gap: 8,
-  },
-  tripItem: {
-    flex: 1,
-    padding: 14,
-    backgroundColor: '#f9f9f9',
-    borderRadius: 8,
-    borderWidth: 1,
-    borderColor: '#eee',
-  },
-  tripItemPressed: {
-    opacity: 0.7,
-    backgroundColor: '#e8f0fe',
-  },
-  leaveButton: {
-    paddingVertical: 10,
-    paddingHorizontal: 14,
-    borderRadius: 8,
-    borderWidth: 1,
-    borderColor: '#e53e3e',
-    backgroundColor: '#fff5f5',
-    minWidth: 60,
-    alignItems: 'center',
-  },
-  leaveButtonPressed: {
-    opacity: 0.7,
-    backgroundColor: '#fed7d7',
-  },
-  leaveButtonText: {
-    color: '#e53e3e',
-    fontSize: 13,
-    fontWeight: '600',
-  },
-  tripName: {
-    fontSize: 16,
-    fontWeight: '500',
-  },
-  tripDescription: {
-    fontSize: 13,
-    color: '#666',
-    marginTop: 2,
-  },
+	debug: {
+		fontSize: 11,
+		color: '#999',
+		fontFamily: 'monospace',
+		marginBottom: 8,
+	},
+	container: {
+		flexGrow: 1,
+		padding: 24,
+		paddingTop: 64,
+	},
+	title: {
+		fontSize: 28,
+		fontWeight: 'bold',
+		marginBottom: 4,
+	},
+	subtitle: {
+		fontSize: 14,
+		color: '#666',
+		marginBottom: 32,
+	},
+	input: {
+		borderWidth: 1,
+		borderColor: '#ddd',
+		borderRadius: 8,
+		padding: 12,
+		fontSize: 16,
+		marginBottom: 12,
+		backgroundColor: '#fff',
+	},
+	inputMultiline: {
+		height: 80,
+		textAlignVertical: 'top',
+	},
+	error: {
+		color: '#e53e3e',
+		fontSize: 14,
+		marginBottom: 12,
+	},
+	button: {
+		backgroundColor: '#3b82f6',
+		borderRadius: 8,
+		padding: 14,
+		alignItems: 'center',
+		marginTop: 4,
+	},
+	buttonPressed: {
+		opacity: 0.8,
+	},
+	buttonText: {
+		color: '#fff',
+		fontSize: 16,
+		fontWeight: '600',
+	},
+	secondaryButton: {
+		backgroundColor: 'transparent',
+		borderWidth: 1,
+		borderColor: '#3b82f6',
+		borderRadius: 8,
+		padding: 14,
+		alignItems: 'center',
+		marginTop: 12,
+	},
+	secondaryButtonPressed: {
+		opacity: 0.7,
+		backgroundColor: '#f0f7ff',
+	},
+	secondaryButtonText: {
+		color: '#3b82f6',
+		fontSize: 16,
+		fontWeight: '600',
+	},
+	tripList: {
+		marginTop: 40,
+	},
+	listTitle: {
+		fontSize: 16,
+		fontWeight: '600',
+		marginBottom: 4,
+		color: '#333',
+	},
+	listSubtitle: {
+		fontSize: 13,
+		color: '#666',
+		marginBottom: 16,
+	},
+	tripRow: {
+		flexDirection: 'row',
+		alignItems: 'center',
+		marginBottom: 8,
+		gap: 8,
+	},
+	tripItem: {
+		flex: 1,
+		padding: 14,
+		backgroundColor: '#f9f9f9',
+		borderRadius: 8,
+		borderWidth: 1,
+		borderColor: '#eee',
+	},
+	tripItemPressed: {
+		opacity: 0.7,
+		backgroundColor: '#e8f0fe',
+	},
+	leaveButton: {
+		paddingVertical: 10,
+		paddingHorizontal: 14,
+		borderRadius: 8,
+		borderWidth: 1,
+		borderColor: '#e53e3e',
+		backgroundColor: '#fff5f5',
+		minWidth: 60,
+		alignItems: 'center',
+	},
+	leaveButtonPressed: {
+		opacity: 0.7,
+		backgroundColor: '#fed7d7',
+	},
+	leaveButtonText: {
+		color: '#e53e3e',
+		fontSize: 13,
+		fontWeight: '600',
+	},
+	tripName: {
+		fontSize: 16,
+		fontWeight: '500',
+	},
+	tripDescription: {
+		fontSize: 13,
+		color: '#666',
+		marginTop: 2,
+	},
+	deleteButton: {
+		backgroundColor: '#fee2e2',
+		borderRadius: 8,
+		paddingVertical: 10,
+		paddingHorizontal: 14,
+		borderWidth: 1,
+		borderColor: '#fca5a5',
+	},
+	deleteButtonPressed: {
+		opacity: 0.7,
+	},
+	deleteButtonText: {
+		color: '#dc2626',
+		fontSize: 14,
+		fontWeight: '600',
+	},
 });

--- a/services/__tests__/trip.service.test.ts
+++ b/services/__tests__/trip.service.test.ts
@@ -1,4 +1,18 @@
+<<<<<<< HEAD
 import { createTripSchema } from '@/types/trip.types';
+||||||| parent of cda5913 (added delete trip)
+import { supabase } from '@/lib/supabase';
+import { getSupabaseAdmin } from '@/lib/supabase.admin';
+import { createTrip, getTripParticipant, updateParticipantRole } from '../trip.service';
+import { createTripSchema, TripRole } from '@/types/trip.types';
+import { createTestUser, TEST_PASSWORD, type TestUser } from '@/__integration__/helpers/user';
+=======
+import { supabase } from '@/lib/supabase';
+import { getSupabaseAdmin } from '@/lib/supabase.admin';
+import { createTrip, deleteTrip, getTripParticipant, updateParticipantRole } from '../trip.service';
+import { createTripSchema, TripRole } from '@/types/trip.types';
+import { createTestUser, TEST_PASSWORD, type TestUser } from '@/__integration__/helpers/user';
+>>>>>>> cda5913 (added delete trip)
 
 // Pure Zod schema tests — no Supabase dependency.
 // Service behaviour is covered by __integration__/trip.test.ts,
@@ -33,3 +47,414 @@ describe('createTripSchema', () => {
     expect(createTripSchema.safeParse({}).success).toBe(false);
   });
 });
+<<<<<<< HEAD
+||||||| parent of cda5913 (added delete trip)
+
+// ---------------------------------------------------------------------------
+// createTrip
+// ---------------------------------------------------------------------------
+
+describe('createTrip', () => {
+  it('creates a trip and returns it with the correct name', async () => {
+    const trip = await createTrip({ name: 'New Integration Trip' });
+    extraTripIds.push(trip.id);
+
+    expect(trip.id).toBeDefined();
+    expect(trip.name).toBe('New Integration Trip');
+  });
+
+  it('sets organizer_id to the authenticated user', async () => {
+    const trip = await createTrip({ name: 'Organizer ID Trip' });
+    extraTripIds.push(trip.id);
+
+    expect(trip.organizer_id).toBe(organizer.id);
+  });
+
+  it('persists the trip so it can be fetched back via admin', async () => {
+    const trip = await createTrip({ name: 'Persistent Trip' });
+    extraTripIds.push(trip.id);
+
+    const { data, error } = await getSupabaseAdmin()
+      .from('trip')
+      .select('*')
+      .eq('id', trip.id)
+      .single();
+
+    expect(error).toBeNull();
+    expect(data?.name).toBe('Persistent Trip');
+  });
+
+  it('stores optional description when provided', async () => {
+    const trip = await createTrip({ name: 'Described Trip', description: 'Some details' });
+    extraTripIds.push(trip.id);
+
+    expect(trip.description).toBe('Some details');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getTripParticipant
+// ---------------------------------------------------------------------------
+
+describe('getTripParticipant', () => {
+  it('returns the participant row with all correct fields', async () => {
+    const result = await getTripParticipant(tripId, organizer.id);
+
+    expect(result.trip_id).toBe(tripId);
+    expect(result.user_id).toBe(organizer.id);
+    expect(result.role).toBe(TripRole.Organizer);
+    expect(result.id).toBeDefined();
+    expect(result.created_at).toBeDefined();
+  });
+
+  it('throws when no participant record exists for that user/trip combo', async () => {
+    await expect(
+      getTripParticipant(tripId, '00000000-0000-0000-0000-000000000000')
+    ).rejects.toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateParticipantRole — organizer actor
+// ---------------------------------------------------------------------------
+
+describe('updateParticipantRole — organizer actor', () => {
+  it('promotes target participant → coOrganizer and persists the change', async () => {
+    const result = await updateParticipantRole(tripId, organizer.id, target.id, TripRole.CoOrganizer);
+
+    expect(result.role).toBe(TripRole.CoOrganizer);
+
+    const { data } = await getSupabaseAdmin()
+      .from('trip_participant')
+      .select('role')
+      .eq('trip_id', tripId)
+      .eq('user_id', target.id)
+      .single();
+    expect(data?.role).toBe(TripRole.CoOrganizer);
+  });
+
+  it('promotes target participant → organizer', async () => {
+    const result = await updateParticipantRole(tripId, organizer.id, target.id, TripRole.Organizer);
+
+    expect(result.role).toBe(TripRole.Organizer);
+  });
+
+  it('demotes coOrganizer → participant', async () => {
+    await getSupabaseAdmin()
+      .from('trip_participant')
+      .update({ role: TripRole.CoOrganizer })
+      .eq('trip_id', tripId)
+      .eq('user_id', target.id);
+
+    const result = await updateParticipantRole(tripId, organizer.id, target.id, TripRole.Participant);
+
+    expect(result.role).toBe(TripRole.Participant);
+  });
+
+  it('returns the updated participant row', async () => {
+    const result = await updateParticipantRole(tripId, organizer.id, target.id, TripRole.CoOrganizer);
+
+    expect(result.trip_id).toBe(tripId);
+    expect(result.user_id).toBe(target.id);
+    expect(result.role).toBe(TripRole.CoOrganizer);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateParticipantRole — coOrganizer actor
+// ---------------------------------------------------------------------------
+
+describe('updateParticipantRole — coOrganizer actor', () => {
+  it('promotes target participant → coOrganizer', async () => {
+    const result = await updateParticipantRole(tripId, coOrg.id, target.id, TripRole.CoOrganizer);
+
+    expect(result.role).toBe(TripRole.CoOrganizer);
+  });
+
+  it('demotes another coOrganizer → participant', async () => {
+    await getSupabaseAdmin()
+      .from('trip_participant')
+      .update({ role: TripRole.CoOrganizer })
+      .eq('trip_id', tripId)
+      .eq('user_id', target.id);
+
+    const result = await updateParticipantRole(tripId, coOrg.id, target.id, TripRole.Participant);
+
+    expect(result.role).toBe(TripRole.Participant);
+  });
+
+  it('throws when trying to promote anyone to organizer', async () => {
+    await expect(
+      updateParticipantRole(tripId, coOrg.id, target.id, TripRole.Organizer)
+    ).rejects.toThrow('Co-organizers cannot promote to organizer.');
+  });
+
+  it("throws when trying to change an organizer's role", async () => {
+    await expect(
+      updateParticipantRole(tripId, coOrg.id, organizer.id, TripRole.Participant)
+    ).rejects.toThrow("Co-organizers cannot change an organizer's role.");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateParticipantRole — participant actor
+// ---------------------------------------------------------------------------
+
+describe('updateParticipantRole — participant actor', () => {
+  it('throws regardless of target role or new role', async () => {
+    await expect(
+      updateParticipantRole(tripId, target.id, coOrg.id, TripRole.Participant)
+    ).rejects.toThrow('Participants do not have permission to change roles.');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateParticipantRole — null role actor
+// ---------------------------------------------------------------------------
+
+describe('updateParticipantRole — null role actor', () => {
+  it('throws when actor has no role set', async () => {
+    await getSupabaseAdmin()
+      .from('trip_participant')
+      .update({ role: null })
+      .eq('trip_id', tripId)
+      .eq('user_id', target.id);
+
+    await expect(
+      updateParticipantRole(tripId, target.id, coOrg.id, TripRole.CoOrganizer)
+    ).rejects.toThrow('Participants do not have permission to change roles.');
+  });
+});
+=======
+
+// ---------------------------------------------------------------------------
+// createTrip
+// ---------------------------------------------------------------------------
+
+describe('createTrip', () => {
+  it('creates a trip and returns it with the correct name', async () => {
+    const trip = await createTrip({ name: 'New Integration Trip' });
+    extraTripIds.push(trip.id);
+
+    expect(trip.id).toBeDefined();
+    expect(trip.name).toBe('New Integration Trip');
+  });
+
+  it('sets organizer_id to the authenticated user', async () => {
+    const trip = await createTrip({ name: 'Organizer ID Trip' });
+    extraTripIds.push(trip.id);
+
+    expect(trip.organizer_id).toBe(organizer.id);
+  });
+
+  it('persists the trip so it can be fetched back via admin', async () => {
+    const trip = await createTrip({ name: 'Persistent Trip' });
+    extraTripIds.push(trip.id);
+
+    const { data, error } = await getSupabaseAdmin()
+      .from('trip')
+      .select('*')
+      .eq('id', trip.id)
+      .single();
+
+    expect(error).toBeNull();
+    expect(data?.name).toBe('Persistent Trip');
+  });
+
+  it('stores optional description when provided', async () => {
+    const trip = await createTrip({ name: 'Described Trip', description: 'Some details' });
+    extraTripIds.push(trip.id);
+
+    expect(trip.description).toBe('Some details');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getTripParticipant
+// ---------------------------------------------------------------------------
+
+describe('getTripParticipant', () => {
+  it('returns the participant row with all correct fields', async () => {
+    const result = await getTripParticipant(tripId, organizer.id);
+
+    expect(result.trip_id).toBe(tripId);
+    expect(result.user_id).toBe(organizer.id);
+    expect(result.role).toBe(TripRole.Organizer);
+    expect(result.id).toBeDefined();
+    expect(result.created_at).toBeDefined();
+  });
+
+  it('throws when no participant record exists for that user/trip combo', async () => {
+    await expect(
+      getTripParticipant(tripId, '00000000-0000-0000-0000-000000000000')
+    ).rejects.toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateParticipantRole — organizer actor
+// ---------------------------------------------------------------------------
+
+describe('updateParticipantRole — organizer actor', () => {
+  it('promotes target participant → coOrganizer and persists the change', async () => {
+    const result = await updateParticipantRole(tripId, organizer.id, target.id, TripRole.CoOrganizer);
+
+    expect(result.role).toBe(TripRole.CoOrganizer);
+
+    const { data } = await getSupabaseAdmin()
+      .from('trip_participant')
+      .select('role')
+      .eq('trip_id', tripId)
+      .eq('user_id', target.id)
+      .single();
+    expect(data?.role).toBe(TripRole.CoOrganizer);
+  });
+
+  it('promotes target participant → organizer', async () => {
+    const result = await updateParticipantRole(tripId, organizer.id, target.id, TripRole.Organizer);
+
+    expect(result.role).toBe(TripRole.Organizer);
+  });
+
+  it('demotes coOrganizer → participant', async () => {
+    await getSupabaseAdmin()
+      .from('trip_participant')
+      .update({ role: TripRole.CoOrganizer })
+      .eq('trip_id', tripId)
+      .eq('user_id', target.id);
+
+    const result = await updateParticipantRole(tripId, organizer.id, target.id, TripRole.Participant);
+
+    expect(result.role).toBe(TripRole.Participant);
+  });
+
+  it('returns the updated participant row', async () => {
+    const result = await updateParticipantRole(tripId, organizer.id, target.id, TripRole.CoOrganizer);
+
+    expect(result.trip_id).toBe(tripId);
+    expect(result.user_id).toBe(target.id);
+    expect(result.role).toBe(TripRole.CoOrganizer);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateParticipantRole — coOrganizer actor
+// ---------------------------------------------------------------------------
+
+describe('updateParticipantRole — coOrganizer actor', () => {
+  it('promotes target participant → coOrganizer', async () => {
+    const result = await updateParticipantRole(tripId, coOrg.id, target.id, TripRole.CoOrganizer);
+
+    expect(result.role).toBe(TripRole.CoOrganizer);
+  });
+
+  it('demotes another coOrganizer → participant', async () => {
+    await getSupabaseAdmin()
+      .from('trip_participant')
+      .update({ role: TripRole.CoOrganizer })
+      .eq('trip_id', tripId)
+      .eq('user_id', target.id);
+
+    const result = await updateParticipantRole(tripId, coOrg.id, target.id, TripRole.Participant);
+
+    expect(result.role).toBe(TripRole.Participant);
+  });
+
+  it('throws when trying to promote anyone to organizer', async () => {
+    await expect(
+      updateParticipantRole(tripId, coOrg.id, target.id, TripRole.Organizer)
+    ).rejects.toThrow('Co-organizers cannot promote to organizer.');
+  });
+
+  it("throws when trying to change an organizer's role", async () => {
+    await expect(
+      updateParticipantRole(tripId, coOrg.id, organizer.id, TripRole.Participant)
+    ).rejects.toThrow("Co-organizers cannot change an organizer's role.");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateParticipantRole — participant actor
+// ---------------------------------------------------------------------------
+
+describe('updateParticipantRole — participant actor', () => {
+  it('throws regardless of target role or new role', async () => {
+    await expect(
+      updateParticipantRole(tripId, target.id, coOrg.id, TripRole.Participant)
+    ).rejects.toThrow('Participants do not have permission to change roles.');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateParticipantRole — null role actor
+// ---------------------------------------------------------------------------
+
+describe('updateParticipantRole — null role actor', () => {
+  it('throws when actor has no role set', async () => {
+    await getSupabaseAdmin()
+      .from('trip_participant')
+      .update({ role: null })
+      .eq('trip_id', tripId)
+      .eq('user_id', target.id);
+
+    await expect(
+      updateParticipantRole(tripId, target.id, coOrg.id, TripRole.CoOrganizer)
+    ).rejects.toThrow('Participants do not have permission to change roles.');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deleteTrip
+// ---------------------------------------------------------------------------
+
+describe('deleteTrip', () => {
+  it('deletes the trip when called by the organizer', async () => {
+    const trip = await createTrip({ name: 'Trip To Delete' });
+
+    await expect(deleteTrip(trip.id)).resolves.toBeUndefined();
+
+    const { data } = await getSupabaseAdmin()
+      .from('trip')
+      .select('id')
+      .eq('id', trip.id)
+      .maybeSingle();
+    expect(data).toBeNull();
+  });
+
+  it('throws when a coOrganizer tries to delete', async () => {
+    const trip = await createTrip({ name: 'Protected Trip - coOrg' });
+    extraTripIds.push(trip.id);
+
+    const admin = getSupabaseAdmin();
+    await admin.from('trip_participant').insert({
+      trip_id: trip.id,
+      user_id: coOrg.id,
+      role: TripRole.CoOrganizer,
+    });
+
+    await supabase.auth.signInWithPassword({ email: coOrg.email, password: TEST_PASSWORD });
+
+    await expect(deleteTrip(trip.id)).rejects.toThrow('Only the organizer can delete a trip.');
+
+    await supabase.auth.signInWithPassword({ email: organizer.email, password: TEST_PASSWORD });
+  });
+
+  it('throws when a participant tries to delete', async () => {
+    const trip = await createTrip({ name: 'Protected Trip - participant' });
+    extraTripIds.push(trip.id);
+
+    const admin = getSupabaseAdmin();
+    await admin.from('trip_participant').insert({
+      trip_id: trip.id,
+      user_id: target.id,
+      role: TripRole.Participant,
+    });
+
+    await supabase.auth.signInWithPassword({ email: target.email, password: TEST_PASSWORD });
+
+    await expect(deleteTrip(trip.id)).rejects.toThrow('Only the organizer can delete a trip.');
+
+    await supabase.auth.signInWithPassword({ email: organizer.email, password: TEST_PASSWORD });
+  });
+});
+>>>>>>> cda5913 (added delete trip)

--- a/services/trip.service.ts
+++ b/services/trip.service.ts
@@ -1,16 +1,16 @@
 import { supabase } from '@/lib/supabase';
 import type { Trip, TripParticipant, TripUpdate } from '@/types';
-import type { CreateTripDTO } from '@/types/trip.types';
+import type { CreateTripDTO, TripWithRole } from '@/types/trip.types';
 import { TripRole } from '@/types/trip.types';
 
-export async function getTrips(): Promise<Trip[]> {
+export async function getTrips(): Promise<TripWithRole[]> {
   const { data: { session } } = await supabase.auth.getSession();
   const userId = session?.user.id;
   if (!userId) return [];
 
   const { data: participantRows, error: participantError } = await supabase
     .from('trip_participant')
-    .select('trip_id')
+    .select('trip_id, role')
     .eq('user_id', userId);
 
   if (participantError) throw participantError;
@@ -18,13 +18,18 @@ export async function getTrips(): Promise<Trip[]> {
   const tripIds = (participantRows ?? []).map((row) => row.trip_id).filter(Boolean) as string[];
   if (tripIds.length === 0) return [];
 
+  const roleMap = new Map(participantRows!.map((row) => [row.trip_id, row.role as TripRole]));
+
   const { data: trips, error: tripsError } = await supabase
     .from('trip')
     .select('*')
     .in('id', tripIds);
 
   if (tripsError) throw tripsError;
-  return trips ?? [];
+  return (trips ?? []).map((trip) => ({
+    ...trip,
+    userRole: roleMap.get(trip.id) ?? TripRole.Participant,
+  }));
 }
 
 export async function getTripById(id: string): Promise<Trip> {
@@ -68,6 +73,15 @@ export async function updateTrip(id: string, updates: TripUpdate): Promise<Trip>
 }
 
 export async function deleteTrip(id: string): Promise<void> {
+  const { data: { user } } = await supabase.auth.getUser();
+  const userId = user?.id;
+  if (!userId) throw new Error('Not authenticated.');
+
+  const participant = await getTripParticipant(id, userId);
+  if (participant.role !== TripRole.Organizer) {
+    throw new Error('Only the organizer can delete a trip.');
+  }
+
   const { error } = await supabase.from('trip').delete().eq('id', id);
   if (error) throw error;
 }

--- a/store/trip.store.ts
+++ b/store/trip.store.ts
@@ -1,10 +1,11 @@
 import { create } from 'zustand';
 import type { Trip, TripParticipant } from '@/types';
-import type { CreateTripDTO } from '@/types/trip.types';
+import type { CreateTripDTO, TripWithRole } from '@/types/trip.types';
 import type { RedeemInviteResponse } from '@/types/invite.types';
 import {
   createTrip as createTripService,
   getTrips as getTripsService,
+  deleteTrip as deleteTripService,
   getTripParticipant,
   leaveTrip as leaveTripService,
 } from '@/services/trip.service';
@@ -16,7 +17,7 @@ import {
 interface TripState {
   currentTrip: Trip | null;
   currentParticipant: TripParticipant | null;
-  trips: Trip[];
+  trips: TripWithRole[];
   participants: TripParticipant[];
   isLoading: boolean;
   inviteUrl: string | null;
@@ -24,11 +25,12 @@ interface TripState {
   isRedeemingInvite: boolean;
   inviteError: string | null;
   setCurrentTrip: (trip: Trip | null) => void;
-  setTrips: (trips: Trip[]) => void;
+  setTrips: (trips: TripWithRole[]) => void;
   setParticipants: (participants: TripParticipant[]) => void;
   setLoading: (isLoading: boolean) => void;
   fetchTrips: () => Promise<void>;
   createTrip: (dto: CreateTripDTO) => Promise<Trip>;
+  deleteTrip: (tripId: string) => Promise<void>;
   fetchCurrentParticipant: (tripId: string, userId: string) => Promise<void>;
   generateInvite: (tripId: string) => Promise<string>;
   redeemInvite: (code: string) => Promise<RedeemInviteResponse>;
@@ -68,6 +70,20 @@ export const useTripStore = create<TripState>()((set) => ({
       const trip = await createTripService(dto);
       set((state) => ({ trips: [...state.trips, trip], isLoading: false }));
       return trip;
+    } catch (error) {
+      set({ isLoading: false });
+      throw error;
+    }
+  },
+
+  deleteTrip: async (tripId) => {
+    set({ isLoading: true });
+    try {
+      await deleteTripService(tripId);
+      set((state) => ({
+        trips: state.trips.filter((t) => t.id !== tripId),
+        isLoading: false,
+      }));
     } catch (error) {
       set({ isLoading: false });
       throw error;

--- a/types/trip.types.ts
+++ b/types/trip.types.ts
@@ -19,3 +19,5 @@ export const createTripSchema = z.object({
 }) satisfies z.ZodType<Omit<TripInsert, 'id' | 'created_at' | 'organizer_id' | 'event_permission'>>;
 
 export type CreateTripDTO = z.infer<typeof createTripSchema>;
+
+export type TripWithRole = import('@/types').Trip & { userRole: TripRole };


### PR DESCRIPTION
## Summary
- Added delete trip functionality with confirmation dialog
- Organizer-only enforcement in service layer + backed by RLS
- Zustand store action updates local state on success
- Integration tests covering organizer, co-organizer, and participant cases

## RLS Policies (trip table)
- **organizer can delete trip** — `DELETE` where `auth.uid() = organizer_id`
- **organizers can delete own trips** — `DELETE` where `auth.uid() = organizer_id`

> ⚠️ These two policies are duplicates — both enforce the same rule. One should be dropped to avoid confusion.

> ⚠️ The application-level organizer check in `deleteTrip` (fetching the participant and checking role) is redundant given the RLS policy already enforces `auth.uid() = organizer_id`. Consider removing the app-level check, or keeping it only for a clearer error message to the user.

## npm audit
Only low-severity vulnerabilities found (in jest-expo/jsdom chain). No high-severity issues. Passes `--audit-level=high`.