### PR TITLE
refactor: enforce arch rules and replace generateUUID with expo-crypto

### DIFF
--- a/app/(app)/(trip)/events/[id].tsx
+++ b/app/(app)/(trip)/events/[id].tsx
@@ -21,12 +21,11 @@ import { EventLocationInput } from '@/components/events/event-location-input';
 import { Input } from '@/components/ui/input';
 import { LocationViewModal } from '@/components/ui/location-view-modal';
 import { useAppTheme } from '@/components/ui/theme-provider';
-import { getEvent, getEventBannerUrl, getEventParticipants, uploadEventBanner } from '@/services/events.service';
 import type { EventParticipant, EventWithCount } from '@/services/events.service';
-import { getProfileImageUrlByPath } from '@/services/profile.service';
 import { EventBannerPicker } from '@/components/events/event-banner-picker';
 import { Container } from '@/components/ui/container';
 import { useEventsStore } from '@/store/events.store';
+import { useProfileStore } from '@/store/profile.store';
 import { useTripStore } from '@/store/trip.store';
 import { Stack } from '@/components/ui/stack';
 import { createEventSchema, TripRole } from '@/types';
@@ -143,7 +142,8 @@ function ViewEvent({ event, onBack, isCreator, isOrganizer, onEdit, onDelete }: 
   const insets = useSafeAreaInsets();
   const { theme: { colors, spacing } } = useAppTheme();
   const { currentParticipant } = useTripStore();
-  const { registerForEvent, unregisterFromEvent } = useEventsStore();
+  const { registerForEvent, unregisterFromEvent, getEventBannerUrl, getEventParticipants } = useEventsStore();
+  const { getProfileImageUrlByPath } = useProfileStore();
   const [locationModalVisible, setLocationModalVisible] = useState(false);
 
   const participantId = currentParticipant?.id;
@@ -378,7 +378,7 @@ function ViewEvent({ event, onBack, isCreator, isOrganizer, onEdit, onDelete }: 
 function EditEvent({ event, onBack, onDeleteSuccess }: { event: EventWithCount; onBack: () => void; onDeleteSuccess: () => void }) {
   const insets = useSafeAreaInsets();
   const { theme: { colors, radius, spacing, stroke } } = useAppTheme();
-  const { updateEvent, deleteEvent } = useEventsStore();
+  const { updateEvent, deleteEvent, getEventBannerUrl, uploadEventBanner } = useEventsStore();
   const { currentParticipant } = useTripStore();
 
   const isOrganizer = currentParticipant?.role === TripRole.Organizer;
@@ -602,7 +602,7 @@ export default function EventScreen() {
   const { id, edit } = useLocalSearchParams<{ id: string; edit?: string }>();
   const router = useRouter();
   const { currentParticipant } = useTripStore();
-  const { events, deleteEvent } = useEventsStore();
+  const { events, deleteEvent, getEvent } = useEventsStore();
 
   const [event, setEvent] = useState<EventWithCount | null>(null);
   const [loading, setLoading] = useState(true);

--- a/components/events/event-detail-modal.tsx
+++ b/components/events/event-detail-modal.tsx
@@ -9,7 +9,6 @@ import { PageSheetModal } from '@/components/ui/page-sheet-modal';
 import { Row } from '@/components/ui/row';
 import { useAppTheme } from '@/components/ui/theme-provider';
 import { ParticipantsList } from '@/components/trip/participants-list';
-import { getEventBannerUrl } from '@/services/events.service';
 import type { EventWithCount } from '@/services/events.service';
 import { useEventsStore } from '@/store/events.store';
 import { useTripStore } from '@/store/trip.store';
@@ -37,7 +36,7 @@ export function EventDetailModal({
 }) {
   const { theme: { colors, spacing, radius, stroke, sizes } } = useAppTheme();
   const { currentParticipant, participantsWithProfiles } = useTripStore();
-  const { registerForEvent, unregisterFromEvent } = useEventsStore();
+  const { registerForEvent, unregisterFromEvent, getEventBannerUrl } = useEventsStore();
 
   const [view, setView] = useState<EventView>('main');
   const [bannerUrl, setBannerUrl] = useState<string | null>(null);

--- a/components/trip/persons-sheet.tsx
+++ b/components/trip/persons-sheet.tsx
@@ -1,5 +1,5 @@
 import { Ionicons } from '@expo/vector-icons';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   ActivityIndicator,
   Alert,
@@ -16,9 +16,9 @@ import { CreateGroupsModal } from '@/components/trip/create-groups-modal';
 import { Avatar } from '@/components/ui/avatar';
 import { AppText } from '@/components/ui/text';
 import { useAppTheme } from '@/components/ui/theme-provider';
-import { deleteGroup, getTripGroupsWithMembers, joinGroup, leaveGroup } from '@/services/group.service';
 import type { GroupWithMembers } from '@/services/group.service';
 import type { TripParticipantWithProfile } from '@/services/trip.service';
+import { useGroupStore } from '@/store/group.store';
 import { TripRole } from '@/types';
 
 const ROLE_LABELS: Record<string, string> = {
@@ -57,9 +57,8 @@ export function PersonsSheet({
   const {
     theme: { colors, opacity, radius, shadows, spacing, stroke, typography },
   } = useAppTheme();
+  const { groups, isLoading: loadingGroups, fetchGroups, joinGroup, leaveGroup, deleteGroup } = useGroupStore();
   const [tab, setTab] = useState<Tab>('people');
-  const [groups, setGroups] = useState<GroupWithMembers[]>([]);
-  const [loadingGroups, setLoadingGroups] = useState(false);
   const [createModalVisible, setCreateModalVisible] = useState(false);
   const [expandedGroupId, setExpandedGroupId] = useState<string | null>(null);
   const [actionLoading, setActionLoading] = useState<string | null>(null);
@@ -68,15 +67,6 @@ export function PersonsSheet({
   const backdropAnim = useRef(new Animated.Value(0)).current;
 
   const sheetMaxHeight = Math.max(screenHeight - insets.top - spacing.xl, 420);
-
-  const refreshGroups = useCallback(() => {
-    if (!tripId) return;
-    setLoadingGroups(true);
-    getTripGroupsWithMembers(tripId)
-      .then(setGroups)
-      .catch(() => undefined)
-      .finally(() => setLoadingGroups(false));
-  }, [tripId]);
 
   useEffect(() => {
     if (!visible) {
@@ -99,9 +89,9 @@ export function PersonsSheet({
     ]).start();
 
     if (tripId) {
-      refreshGroups();
+      void fetchGroups(tripId);
     }
-  }, [backdropAnim, refreshGroups, screenHeight, slideAnim, tripId, visible]);
+  }, [backdropAnim, fetchGroups, screenHeight, slideAnim, tripId, visible]);
 
   const sortedParticipants = useMemo(
     () =>
@@ -133,7 +123,6 @@ export function PersonsSheet({
     setActionLoading(group.id);
     try {
       await joinGroup(group.id, currentParticipantId);
-      refreshGroups();
     } catch (error) {
       const message =
         error instanceof Error && error.message === 'Group is full'
@@ -150,7 +139,6 @@ export function PersonsSheet({
     setActionLoading(group.id);
     try {
       await leaveGroup(group.id, currentParticipantId);
-      refreshGroups();
     } catch {
       Alert.alert('Error', 'Could not leave group. Please try again.');
     } finally {
@@ -168,7 +156,6 @@ export function PersonsSheet({
           setActionLoading(group.id);
           try {
             await deleteGroup(group.id);
-            refreshGroups();
           } catch {
             Alert.alert('Error', 'Could not delete group. Please try again.');
           } finally {
@@ -596,7 +583,6 @@ export function PersonsSheet({
           onClose={closeCreateModal}
           onCreated={() => {
             closeCreateModal();
-            refreshGroups();
           }}
         />
       ) : null}

--- a/components/trip/trip-edit-form.tsx
+++ b/components/trip/trip-edit-form.tsx
@@ -21,7 +21,6 @@ import { useAppTheme } from '@/components/ui/theme-provider';
 import { TripSummaryPreviewCard } from '@/components/trip/trip-summary-preview-card';
 import { useTripStore } from '@/store/trip.store';
 import { TripEventPermission, TripRole } from '@/types';
-import { getTripBannerUrl, uploadTripBanner } from '@/services/trip.service';
 
 type Props = {
   onClose?: () => void;
@@ -86,6 +85,8 @@ export function TripEditForm({ onClose }: Props) {
   const currentParticipant = useTripStore((s) => s.currentParticipant);
   const tripNextActions = useTripStore((s) => s.tripNextActions);
   const updateTrip = useTripStore((s) => s.updateTrip);
+  const getTripBannerUrl = useTripStore((s) => s.getTripBannerUrl);
+  const uploadTripBanner = useTripStore((s) => s.uploadTripBanner);
 
   const canEdit =
     currentParticipant?.role === TripRole.Organizer ||

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "expo-camera": "~17.0.10",
         "expo-clipboard": "~8.0.8",
         "expo-constants": "~18.0.13",
+        "expo-crypto": "~15.0.9",
         "expo-dev-client": "~6.0.20",
         "expo-device": "~8.0.10",
         "expo-document-picker": "~14.0.8",
@@ -7691,6 +7692,18 @@
       "peerDependencies": {
         "expo": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-crypto": {
+      "version": "15.0.9",
+      "resolved": "https://registry.npmjs.org/expo-crypto/-/expo-crypto-15.0.9.tgz",
+      "integrity": "sha512-SNWKa2fXx7v9gkp1h/7nqXY5XN7qgNDn3yRc2aO0gWGbeMbvob/haMxxsPFe9f51aqH5NjNCqHf2kvLhvAd8KQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-dev-client": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "expo-camera": "~17.0.10",
     "expo-clipboard": "~8.0.8",
     "expo-constants": "~18.0.13",
+    "expo-crypto": "~15.0.9",
     "expo-dev-client": "~6.0.20",
     "expo-device": "~8.0.10",
     "expo-document-picker": "~14.0.8",

--- a/services/chat.service.ts
+++ b/services/chat.service.ts
@@ -1,14 +1,7 @@
+import * as Crypto from 'expo-crypto';
 import { supabase } from '@/lib/supabase';
 import { sendMessageSchema, editMessageSchema, sendLocationMessageSchema } from '@/types';
 import type { SendMessageDTO, EditMessageDTO, MessageImage, MessageWithSender, ChatRoomWithMeta, SendLocationMessageDTO, MessageLocationData } from '@/types';
-
-function generateUUID(): string {
-  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
-    const r = (Math.random() * 16) | 0;
-    const v = c === 'x' ? r : (r & 0x3) | 0x8;
-    return v.toString(16);
-  });
-}
 
 function mapToMessageWithSender(raw: {
   id: string;
@@ -61,7 +54,7 @@ export async function uploadChatImage(
   asset: { uri?: string; blob?: Blob; mimeType?: string }
 ): Promise<string> {
   const ext = asset.mimeType?.split('/')[1] ?? 'jpg';
-  const path = `${groupChatId}/${generateUUID()}.${ext}`;
+  const path = `${groupChatId}/${Crypto.randomUUID()}.${ext}`;
   let body: ArrayBuffer | Blob;
   if (asset.blob) {
     body = await asset.blob.arrayBuffer();

--- a/services/events.service.ts
+++ b/services/events.service.ts
@@ -1,21 +1,14 @@
+import * as Crypto from 'expo-crypto';
 import { supabase } from '@/lib/supabase';
 import type { Event, EventInsert, EventParticipationInsert, EventUpdate } from '@/types';
 
 const EVENT_BANNER_BUCKET = 'event_banner';
 
-function generateUUID(): string {
-  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
-    const r = (Math.random() * 16) | 0;
-    const v = c === 'x' ? r : (r & 0x3) | 0x8;
-    return v.toString(16);
-  });
-}
-
 export async function uploadEventBanner(
   localUri: string,
   participantId: string,
 ): Promise<string> {
-  const path = `${participantId}/${generateUUID()}`;
+  const path = `${participantId}/${Crypto.randomUUID()}`;
   const response = await fetch(localUri);
   const arrayBuffer = await response.arrayBuffer();
 

--- a/services/profile.service.ts
+++ b/services/profile.service.ts
@@ -1,15 +1,8 @@
+import * as Crypto from 'expo-crypto';
 import { supabase } from '@/lib/supabase';
 import type { Profile } from '@/types';
 
 const PROFILE_IMAGE_BUCKET = 'profile_image';
-
-function generateUUID(): string {
-  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
-    const r = (Math.random() * 16) | 0;
-    const v = c === 'x' ? r : (r & 0x3) | 0x8;
-    return v.toString(16);
-  });
-}
 
 /**
  * Uploads a local image URI to the profile_image bucket.
@@ -22,7 +15,7 @@ export async function uploadProfileImage(localUri: string): Promise<string> {
   if (!session?.user) throw new Error('No authenticated user');
 
   const userId = session.user.id;
-  const imageId = generateUUID();
+  const imageId = Crypto.randomUUID();
   const storagePath = `${userId}/${imageId}`;
 
   const response = await fetch(localUri);

--- a/services/trip.service.ts
+++ b/services/trip.service.ts
@@ -1,3 +1,4 @@
+import * as Crypto from 'expo-crypto';
 import { supabase } from '@/lib/supabase';
 import type { Profile, Trip, TripParticipant, TripUpdate } from '@/types';
 
@@ -5,7 +6,7 @@ const DESCRIPTION_FILE_BUCKET = 'trip_description';
 const TRIP_BANNER_BUCKET = 'trip_banner';
 
 export async function uploadTripBanner(localUri: string, tripId: string): Promise<string> {
-  const path = `${tripId}/${generateUUID()}`;
+  const path = `${tripId}/${Crypto.randomUUID()}`;
   const response = await fetch(localUri);
   const arrayBuffer = await response.arrayBuffer();
   const { error } = await supabase.storage
@@ -23,21 +24,13 @@ export async function getTripBannerUrl(path: string): Promise<string | null> {
   return data.signedUrl;
 }
 
-function generateUUID(): string {
-  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
-    const r = (Math.random() * 16) | 0;
-    const v = c === 'x' ? r : (r & 0x3) | 0x8;
-    return v.toString(16);
-  });
-}
-
 export async function uploadTripDescriptionFile(
   localUri: string,
   tripId: string,
   fileName: string,
 ): Promise<string> {
   const ext = fileName.split('.').pop() ?? 'pdf';
-  const path = `${tripId}/${generateUUID()}.${ext}`;
+  const path = `${tripId}/${Crypto.randomUUID()}.${ext}`;
   const response = await fetch(localUri);
   const arrayBuffer = await response.arrayBuffer();
 

--- a/store/events.store.ts
+++ b/store/events.store.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
-import type { EventInsert, EventUpdate } from '@/types';
-import type { EventWithCount } from '@/services/events.service';
+import type { Event, EventInsert, EventUpdate } from '@/types';
+import type { EventParticipant, EventWithCount } from '@/services/events.service';
 import {
   getEvents as getEventsService,
   createEvent as createEventService,
@@ -8,6 +8,10 @@ import {
   deleteEvent as deleteEventService,
   registerForEvent as registerForEventService,
   unregisterFromEvent as unregisterFromEventService,
+  getEventBannerUrl as getEventBannerUrlService,
+  getEvent as getEventService,
+  getEventParticipants as getEventParticipantsService,
+  uploadEventBanner as uploadEventBannerService,
 } from '@/services/events.service';
 
 interface EventsState {
@@ -19,6 +23,10 @@ interface EventsState {
   deleteEvent: (id: string) => Promise<void>;
   registerForEvent: (eventId: string, participantId: string) => void;
   unregisterFromEvent: (eventId: string, participantId: string) => void;
+  getEvent: (id: string) => Promise<Event | null>;
+  getEventBannerUrl: (path: string) => Promise<string | null>;
+  getEventParticipants: (eventId: string) => Promise<EventParticipant[]>;
+  uploadEventBanner: (localUri: string, participantId: string) => Promise<string>;
   setEvents: (events: EventWithCount[]) => void;
   setLoading: (isLoading: boolean) => void;
 }
@@ -111,6 +119,11 @@ export const useEventsStore = create<EventsState>()((set) => ({
       }));
     });
   },
+
+  getEvent: (id) => getEventService(id),
+  getEventBannerUrl: (path) => getEventBannerUrlService(path),
+  getEventParticipants: (eventId) => getEventParticipantsService(eventId),
+  uploadEventBanner: (localUri, participantId) => uploadEventBannerService(localUri, participantId),
 
   setEvents: (events) => set({ events }),
   setLoading: (isLoading) => set({ isLoading }),

--- a/store/profile.store.ts
+++ b/store/profile.store.ts
@@ -8,6 +8,7 @@ import {
   updateProfile,
   uploadProfileImage,
   getProfileImageUrl,
+  getProfileImageUrlByPath as getProfileImageUrlByPathService,
 } from '@/services/profile.service';
 
 interface ProfileState {
@@ -23,6 +24,7 @@ interface ProfileState {
   fetchParticipatedTripCount: () => Promise<void>;
   setSelectedTrip: (tripId: string | null) => Promise<void>;
   saveProfileChanges: (changes: { localImageUri?: string; userName?: string | null; phoneNumber?: string | null }) => Promise<void>;
+  getProfileImageUrlByPath: (userId: string, imageId: string) => Promise<string | null>;
 }
 
 export const useProfileStore = create<ProfileState>()((set) => ({
@@ -124,4 +126,6 @@ export const useProfileStore = create<ProfileState>()((set) => ({
       throw error;
     }
   },
+
+  getProfileImageUrlByPath: (userId, imageId) => getProfileImageUrlByPathService(userId, imageId),
 }));

--- a/store/trip.store.ts
+++ b/store/trip.store.ts
@@ -13,6 +13,8 @@ import {
   leaveTrip as leaveTripService,
   updateParticipantRole as updateParticipantRoleService,
   updateTrip as updateTripService,
+  getTripBannerUrl as getTripBannerUrlService,
+  uploadTripBanner as uploadTripBannerService,
   type TripParticipantWithProfile,
 } from '@/services/trip.service';
 import {
@@ -64,6 +66,8 @@ interface TripState {
   generateInvite: (tripId: string) => Promise<string>;
   redeemInvite: (code: string) => Promise<RedeemInviteResponse>;
   leaveTrip: (tripId: string) => Promise<void>;
+  getTripBannerUrl: (path: string) => Promise<string | null>;
+  uploadTripBanner: (localUri: string, tripId: string) => Promise<string>;
 }
 
 export const useTripStore = create<TripState>()((set) => ({
@@ -264,4 +268,7 @@ export const useTripStore = create<TripState>()((set) => ({
       ),
     }));
   },
+
+  getTripBannerUrl: (path) => getTripBannerUrlService(path),
+  uploadTripBanner: (localUri, tripId) => uploadTripBannerService(localUri, tripId),
 }));


### PR DESCRIPTION
- Replace Math.random()-based generateUUID() in all service files with Crypto.randomUUID() from expo-crypto (fixes runtime crash on Hermes)
- Route all direct service calls in components through Zustand stores to comply with Component → Store → Service → Supabase data flow
- Add pass-through store actions to events, trip, and profile stores
- Refactor persons-sheet to use group store instead of calling group service directly