### PR TITLE
feat: navigate to chat room on notification tap

### DIFF
--- a/app/(app)/_layout.tsx
+++ b/app/(app)/_layout.tsx
@@ -4,6 +4,7 @@ import { GlobalProfileButton } from '@/components/layout';
 import { useProfileStore } from '@/store/profile.store';
 import { useAuthStore } from '@/store/auth.store';
 import { usePushNotifications } from '@/hooks/use-push-notifications';
+import { useNotificationNavigation } from '@/hooks/use-notification-navigation';
 import { useAppTheme } from '@/components/ui/theme-provider';
 
 export default function AppLayout() {
@@ -16,6 +17,7 @@ export default function AppLayout() {
 	}, []);
 
 	usePushNotifications(session?.user.id);
+	useNotificationNavigation();
 
 	return (
 		<>

--- a/hooks/use-notification-navigation.ts
+++ b/hooks/use-notification-navigation.ts
@@ -1,0 +1,40 @@
+import { useEffect, useRef } from 'react';
+import { router } from 'expo-router';
+import * as Notifications from 'expo-notifications';
+import { useProfileStore } from '@/store/profile.store';
+
+export function useNotificationNavigation() {
+  const { selectedTrip, setSelectedTrip } = useProfileStore();
+  const handledNotificationId = useRef<string | null>(null);
+  const pendingChatNav = useRef<{ tripId: string; roomId: string } | null>(null);
+  const lastNotificationResponse = Notifications.useLastNotificationResponse();
+
+  // Capture notification tap; switch trip only if needed
+  useEffect(() => {
+    if (!lastNotificationResponse) return;
+    const notifId = lastNotificationResponse.notification.request.identifier;
+    if (handledNotificationId.current === notifId) return;
+    handledNotificationId.current = notifId;
+
+    const data = lastNotificationResponse.notification.request.content.data;
+    const roomId = data?.group_chat_id as string | undefined;
+    const tripId = data?.trip_id as string | undefined;
+    if (!roomId || !tripId) return;
+
+    if (selectedTrip === tripId) {
+      router.push(`/(app)/(trip)/chat/${roomId}`);
+    } else {
+      pendingChatNav.current = { tripId, roomId };
+      setSelectedTrip(tripId);
+    }
+  }, [lastNotificationResponse]);
+
+  // Navigate once selectedTrip has updated to the target trip
+  useEffect(() => {
+    if (!pendingChatNav.current || !selectedTrip) return;
+    if (selectedTrip !== pendingChatNav.current.tripId) return;
+    const { roomId } = pendingChatNav.current;
+    pendingChatNav.current = null;
+    router.push(`/(app)/(trip)/chat/${roomId}`);
+  }, [selectedTrip]);
+}

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -39,3 +39,10 @@ entrypoint = "./functions/send-notification/index.ts"
 verify_jwt = false
 import_map = "./functions/webhook-announcement-notification/deno.json"
 entrypoint = "./functions/webhook-announcement-notification/index.ts"
+
+# Webhook target — called only from the Supabase database trigger on message INSERT.
+# JWT verification is disabled because the caller is the Supabase trigger itself, not a user.
+[functions.webhook-chat-message-notification]
+verify_jwt = false
+import_map = "./functions/webhook-chat-message-notification/deno.json"
+entrypoint = "./functions/webhook-chat-message-notification/index.ts"

--- a/supabase/functions/webhook-chat-message-notification/index.ts
+++ b/supabase/functions/webhook-chat-message-notification/index.ts
@@ -29,7 +29,7 @@ Deno.serve(async (req) => {
   try {
     const [profileRes, roomRes] = await Promise.all([
       supabase.from("profile").select("user_name").eq("id", senderId).single(),
-      supabase.from("group_chat").select("chat_name").eq("id", chatRoomId).single(),
+      supabase.from("group_chat").select("chat_name, trip_id").eq("id", chatRoomId).single(),
     ]);
 
     const senderName = profileRes.data?.user_name ?? "Someone";
@@ -41,7 +41,7 @@ Deno.serve(async (req) => {
       : `${senderName} sent a photo`;
 
     const tokens = await getPushTokensForChatRoomExcluding(chatRoomId, senderId);
-    const res = await sendNotification(tokens, roomName, body, { group_chat_id: chatRoomId });
+    const res = await sendNotification(tokens, roomName, body, { group_chat_id: chatRoomId, trip_id: roomRes.data?.trip_id });
     return new Response(JSON.stringify(res), {
       headers: { "Content-Type": "application/json" },
     });


### PR DESCRIPTION
Tapping a push notification now opens the correct chat room in the correct trip context. Adds trip_id to the notification payload, a new useNotificationNavigation hook that handles trip switching before navigating, and fixes the Edge Function 401 caused by missing verify_jwt = false in config.toml.