### PR TITLE
Add EXPO_PUBLIC env vars to production build profile

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -12,7 +12,11 @@
       "distribution": "internal"
     },
     "production": {
-      "autoIncrement": true
+      "autoIncrement": true,
+      "env": {
+        "EXPO_PUBLIC_SUPABASE_URL": "https://ccyrwyfmijmqijpyvefo.supabase.co/",
+        "EXPO_PUBLIC_SUPABASE_KEY": "sb_publishable_mShwSLqI9nGrYqiamkc5_A_683OC6tz"
+      }
     }
   },
   "submit": {


### PR DESCRIPTION
Bakes the Supabase anon URL and key into the EAS production build so local builds (eas build --local) pick them up — .env.local is gitignored and not available during local EAS builds.